### PR TITLE
Fixes for unicode passwords, and encoded_url "as varname" syntax

### DIFF
--- a/urlcrypt/lib.py
+++ b/urlcrypt/lib.py
@@ -52,7 +52,7 @@ deobfuscate = obfuscate
 
 def encode_token(strings, secret_key_f):
     secret_key = secret_key_f(*strings)
-    signature = hmac.new(secret_key, pack(*strings), sha_hmac).hexdigest()
+    signature = hmac.new(str(secret_key), pack(*strings), sha_hmac).hexdigest()
     packed_string = pack(signature, *strings)
     return obfuscate(packed_string)
 

--- a/urlcrypt/templatetags/urlcrypt_tags.py
+++ b/urlcrypt/templatetags/urlcrypt_tags.py
@@ -16,9 +16,15 @@ class EncodedURLNode(URLNode):
     
     def render(self, context):
         url = super(EncodedURLNode, self).render(context)
+        if self.asvar:
+            url = context[self.asvar]
         user = self.user.resolve(context)
         token = generate_login_token(user, url)
-        return reverse('urlcrypt_redirect', args=(token,))
+        crypt_url = reverse('urlcrypt_redirect', args=(token,))
+        if self.asvar:
+            context[self.asvar] = crypt_url
+            return ''
+        return crypt_url
 
 @register.tag
 def encoded_url(parser, token):


### PR DESCRIPTION
Fixes for these issues:
- hmac borking on unicode passwords: https://github.com/dziegler/django-urlcrypt/issues#issue/3
- encoded_url and "as varname" syntax: https://github.com/dziegler/django-urlcrypt/issues#issue/4
  as well as tests for both.  
