### PR TITLE
Fix Rate Limiting

### DIFF
--- a/urlcrypt/tests.py
+++ b/urlcrypt/tests.py
@@ -7,7 +7,7 @@ from django.core.urlresolvers import reverse
 
 from django.test import TestCase
 from urlcrypt.lib import generate_login_token, decode_login_token, encode_token, base64url_encode
-from urlcrypt.conf import URLCRYPT_LOGIN_URL, URLCRYPT_USE_RSA_ENCRYPTION
+from urlcrypt.conf import URLCRYPT_LOGIN_URL, URLCRYPT_USE_RSA_ENCRYPTION, URLCRYPT_RATE_LIMIT
 
 class UrlCryptTests(TestCase):
     
@@ -100,7 +100,7 @@ class UrlCryptTests(TestCase):
         for i in xrange(100):
             token = generate_login_token(self.test_user, u'/users/following')
             response = self.client.get(reverse('urlcrypt_redirect', args=(token,)))
-            if 0 <= i <= 60:
+            if 0 <= i <= URLCRYPT_RATE_LIMIT:
                 self.assertEqual(response.status_code, 302)
             else:
                 self.assertEqual(response.status_code, 403)

--- a/urlcrypt/tests.py
+++ b/urlcrypt/tests.py
@@ -95,3 +95,13 @@ class UrlCryptTests(TestCase):
         encoded_url = t.render(c).strip()
         self.assert_login_url(encoded_url, reverse('urlcrypt_test_view_username', args=(self.test_user.username,)))
      
+
+    def test_rate_limiting(self):
+        for i in xrange(100):
+            token = generate_login_token(self.test_user, u'/users/following')
+            response = self.client.get(reverse('urlcrypt_redirect', args=(token,)))
+            if 0 <= i <= 60:
+                self.assertEqual(response.status_code, 302)
+            else:
+                self.assertEqual(response.status_code, 403)
+                self.assertEqual(response.content, "Rate Limit Exceeded")

--- a/urlcrypt/views.py
+++ b/urlcrypt/views.py
@@ -21,7 +21,7 @@ def rate_limit(num=60):
             else:
                 num_tries = cache.incr(cache_key, delta=1)
             if num_tries > num:
-                raise HttpResponseForbidden("Rate Limit Exceeded")
+                return HttpResponseForbidden("Rate Limit Exceeded")
             return func(request, *args, **kwargs)
         return wrapper
     return decorator


### PR DESCRIPTION
Fixed rate limiting to return (not raise) HttpResponseForbidden. The view was generating a "TypeError: exceptions must be classes or instances, not HttpResponseForbidden". Also added tests.
