### PR TITLE
encode_url_string tag appears to be broken.

### DIFF
--- a/urlcrypt/__init__.py
+++ b/urlcrypt/__init__.py
@@ -1,3 +1,2 @@
-VERSION = (0, 1, 6)
+VERSION = (0, 1, 6, '1a')
 __version__ = '.'.join(map(str, VERSION))
-

--- a/urlcrypt/templatetags/urlcrypt_tags.py
+++ b/urlcrypt/templatetags/urlcrypt_tags.py
@@ -9,11 +9,11 @@ from urlcrypt.lib import generate_login_token
 register = template.Library()
 
 class EncodedURLNode(URLNode):
-    
+
     def __init__(self, user, *args, **kwargs):
         self.user = template.Variable(user)
         super(EncodedURLNode, self).__init__(*args, **kwargs)
-    
+
     def render(self, context):
         url = super(EncodedURLNode, self).render(context)
         if self.asvar:
@@ -56,10 +56,8 @@ def encoded_url(parser, token):
 
 @register.simple_tag
 def encode_url_string(user, url):
-    if RUNNING_TESTS:
-        domain = 'testserver'
-    else:
-        domain = Site.objects.get_current().domain
-    protocol, suffix = url.split("://%s" % domain)
-    token = generate_login_token(user, suffix)
-    return "%s://%s" % (protocol, reverse('urlcrypt_redirect', args=(token,)))
+    """
+    Encodes URL passed in directly as string (no url reversal).
+    """
+    token = generate_login_token(user, url)
+    return reverse('urlcrypt_redirect', args=(token,))


### PR DESCRIPTION
I'm probably missing something, but in its current state, the template tag "encode_url_string" is broken. 

I couldn't see any reason for URL munging and figure it should just encode a URL based on whatever is inputted. Protocol or no protocol, domain or no domain, whatever... 

I stripped out those pieces and simplified the method. Works in every case I tested (assuming the URL passed in is actually valid).
