### PR TITLE
Compatibility to Django 1.6 (and later?)

### DIFF
--- a/urlcrypt/urls.py
+++ b/urlcrypt/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 from urlcrypt.conf import RUNNING_TESTS
 
 if RUNNING_TESTS:


### PR DESCRIPTION
django.conf.urls.defaults has been removed in Django 1.6
